### PR TITLE
Fix same-name variable/func param (Swift 6.0) bug.

### DIFF
--- a/Sources/GalahInterpreter/TypeChecker.swift
+++ b/Sources/GalahInterpreter/TypeChecker.swift
@@ -544,7 +544,7 @@ public struct TypeChecker {
     ) -> Result<WithDiagnostics<CheckedAST.Fn>, [Diagnostic]> {
         #result { (analyzedStmts: Analyzed<[CheckedAST.Stmt]>) in
             let span = fn.span
-            let fn = *fn
+            let fnInner = *fn
 
             var context = FnContext(
                 globalContext: globalContext,
@@ -554,8 +554,8 @@ public struct TypeChecker {
                 context.newLocal(param.ident, type: param.type)
             }
 
-            analyzedStmts <- checkStmts(fn.stmts, &context)
-            let returnType = fn.signature.inner.returnType?.inner ?? .void
+            analyzedStmts <- checkStmts(fnInner.stmts, &context)
+            let returnType = fnInner.signature.inner.returnType?.inner ?? .void
             guard returnType == .void || analyzedStmts.returnsOnAllPaths else {
                 // TODO: Attach the diagnostic to the last statement in each offending path
                 return .failure([


### PR DESCRIPTION
* Somehow, when using a same-name variable inside the body of a swift function that matches with the same-name of a function parameter, a swift llvm bug incurs a strange indirection that causes the function parameter's type to mutate into the same-name variable's type.

<img width="1009" alt="Screenshot 2024-07-07 at 12 23 00 PM" src="https://github.com/stackotter/galah/assets/18516968/5af70a9f-18b9-46da-8352-486348f59a9e">
