### PR TITLE
Fix closure parameter clause (Swift 5.10), bump dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+/.vscode

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftwasm/carton",
       "state" : {
-        "revision" : "85fa55e4f9cbfa68d37dc7050ba7952fed300a2c",
-        "version" : "1.0.3"
+        "revision" : "d3f1da61faa05283e46a05698ac9bea46fd1035f",
+        "version" : "1.1.2"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftwasm/JavaScriptKit",
       "state" : {
-        "revision" : "2d7bc960eed438dce7355710ece43fa004bbb3ac",
-        "version" : "0.15.0"
+        "revision" : "bfaba41ab62aaa89080f9d467eb68497e77a8a10",
+        "version" : "0.20.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stackotter/swift-macro-toolkit",
       "state" : {
-        "revision" : "106daeb38eb3f52b1540aed981fc63fa22274576",
-        "version" : "0.3.1"
+        "revision" : "687075e7bf976e121d083e922a07c7a9350ca85d",
+        "version" : "0.4.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b",
-        "version" : "509.0.0"
+        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
+        "version" : "510.0.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -35,14 +35,14 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(
             url: "https://github.com/apple/swift-syntax.git",
-            from: "509.0.0"
+            from: "510.0.3"
         ),
         .package(
             url: "https://github.com/stackotter/swift-macro-toolkit",
-            from: "0.3.1"
+            from: "0.4.0"
         ),
-        .package(url: "https://github.com/swiftwasm/carton", from: "1.0.0"),
-        .package(url: "https://github.com/swiftwasm/JavaScriptKit", exact: "0.15.0"),
+        .package(url: "https://github.com/swiftwasm/carton", from: "1.1.2"),
+        .package(url: "https://github.com/swiftwasm/JavaScriptKit", exact: "0.20.0"),
     ],
     targets: [
         .executableTarget(

--- a/Sources/UtilityMacrosPlugin/ResultMacro.swift
+++ b/Sources/UtilityMacrosPlugin/ResultMacro.swift
@@ -112,7 +112,7 @@ public struct ResultMacro: ExpressionMacro {
         of node: some FreestandingMacroExpansionSyntax,
         in context: some MacroExpansionContext
     ) throws -> ExprSyntax {
-        guard node.argumentList.isEmpty, node.additionalTrailingClosures.isEmpty else {
+        guard node.arguments.isEmpty, node.additionalTrailingClosures.isEmpty else {
             throw MacroError("#result expects a single trailing closure")
         }
 
@@ -140,8 +140,7 @@ public struct ResultMacro: ExpressionMacro {
         let rewriter = ArrowSyntaxRewriter(context: context, contextVariables: contextVariables)
         closure.statements = rewriter.rewrite(closure.statements, detach: true).as(
             CodeBlockItemListSyntax.self)!
-        closure.signature?.parameterClause = ClosureParameterClauseSyntax.init(parameters: [])
-            .as(ClosureSignatureSyntax.ParameterClause.self)
+        closure.signature?.parameterClause = ClosureSignatureSyntax.ParameterClause.parameterClause(.init(parameters: []))
 
         guard rewriter.diagnostics.isEmpty else {
             for diagnostic in rewriter.diagnostics {


### PR DESCRIPTION
* Upgrade to **Swift Syntax 5.10**:
  * The closure parameter clause broke since the previous cast that was used previously had been set by **Swift Syntax** to always fail.
  * There is no longer a **`node.argumentList`** property, it is now called **`node.arguments`**.
* Bump **Swift Syntax** to **v510.0.3**.
* Bump **Swift Macro Toolkit** to **v0.4.0**.
* Bump **SwiftWasm Carton** to **v1.1.2**.
* Bump **SwiftWasm JavaScriptKit** to **v0.20.0**.